### PR TITLE
feat: #73 검증, 재생성 관련 kafka 기능 추가

### DIFF
--- a/src/main/java/com/example/demo/constants/KafkaConstants.java
+++ b/src/main/java/com/example/demo/constants/KafkaConstants.java
@@ -1,0 +1,11 @@
+package com.example.demo.constants;
+
+public class KafkaConstants {
+
+    public static final String AI_REQUEST_TOPIC = "ai-report-request";
+    public static final String AI_RESPONSE_TOPIC = "ai-report-response";
+    public static final String VALIDATION_REQUEST_TOPIC = "ai-validation-request";
+    public static final String VALIDATION_RESPONSE_TOPIC = "ai-validation-response";
+    public static final String REVISION_REQUEST_TOPIC = "ai-revision-request";
+    public static final String REVISION_RESPONSE_TOPIC = "ai-revision-response";
+}

--- a/src/main/java/com/example/demo/dto/graphvalidator/CheckRequestDto.java
+++ b/src/main/java/com/example/demo/dto/graphvalidator/CheckRequestDto.java
@@ -1,10 +1,12 @@
 package com.example.demo.dto.graphvalidator;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class CheckRequestDto {
+    @JsonProperty("induty_name")
     @NotBlank private String indutyName;
     @NotBlank private String section;
     @NotBlank private String draft;

--- a/src/main/java/com/example/demo/dto/kafka/RevisionRequestDto.java
+++ b/src/main/java/com/example/demo/dto/kafka/RevisionRequestDto.java
@@ -1,0 +1,19 @@
+package com.example.demo.dto.kafka;
+
+import com.example.demo.dto.graphvalidator.ValidationDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RevisionRequestDto {
+    @JsonProperty("request_id")
+    private String requestId;
+    @JsonProperty("issue")
+    private ValidationDto.Issue issue;
+}

--- a/src/main/java/com/example/demo/dto/kafka/RevisionResponseDto.java
+++ b/src/main/java/com/example/demo/dto/kafka/RevisionResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.demo.dto.kafka;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RevisionResponseDto {
+    @JsonProperty("request_id")
+    private String requestId;
+    @JsonProperty("status")
+    private String status;
+    @JsonProperty("revised_content")
+    private String revisedContent;
+    @JsonProperty("error_message")
+    private String errorMessage;
+}

--- a/src/main/java/com/example/demo/dto/kafka/ValidationRequestDto.java
+++ b/src/main/java/com/example/demo/dto/kafka/ValidationRequestDto.java
@@ -1,0 +1,22 @@
+package com.example.demo.dto.kafka;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ValidationRequestDto {
+    @JsonProperty("request_id")
+    private String requestId;
+    @JsonProperty("induty_name")
+    private String indutyName;
+    @JsonProperty("section")
+    private String section;
+    @JsonProperty("draft")
+    private String draft;
+}

--- a/src/main/java/com/example/demo/dto/kafka/ValidationResponseDto.java
+++ b/src/main/java/com/example/demo/dto/kafka/ValidationResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.demo.dto.kafka;
+
+import com.example.demo.dto.graphvalidator.ValidationDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ValidationResponseDto {
+    @JsonProperty("request_id")
+    private String requestId;
+    @JsonProperty("status")
+    private String status; // "SUCCESS", "ERROR"
+    @JsonProperty("validation_result")
+    private ValidationDto validationResult;
+    @JsonProperty("error_message")
+    private String errorMessage;
+}

--- a/src/main/java/com/example/demo/kafka/KafkaValidationConsumer.java
+++ b/src/main/java/com/example/demo/kafka/KafkaValidationConsumer.java
@@ -1,0 +1,84 @@
+package com.example.demo.kafka;
+
+import com.example.demo.dto.graphvalidator.CheckRequestDto;
+import com.example.demo.dto.graphvalidator.ValidationDto;
+import com.example.demo.dto.kafka.RevisionRequestDto;
+import com.example.demo.dto.kafka.RevisionResponseDto;
+import com.example.demo.dto.kafka.ValidationRequestDto;
+import com.example.demo.dto.kafka.ValidationResponseDto;
+import com.example.demo.service.graphvalidator.CheckService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import static com.example.demo.constants.KafkaConstants.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KafkaValidationConsumer {
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+    private final CheckService checkService;
+
+    @KafkaListener(topics = VALIDATION_REQUEST_TOPIC, groupId = "ai-server-group")
+    public void consumeValidationRequest(String message) {
+        try {
+            ValidationRequestDto request = objectMapper.readValue(message, ValidationRequestDto.class);
+
+            String indutyName = request.getIndutyName();
+            String section = request.getSection();
+            String draft = request.getDraft();
+
+            CheckRequestDto checkRequest = new CheckRequestDto();
+            checkRequest.setIndutyName(indutyName != null ? indutyName : "UNKNOWN");
+            checkRequest.setSection(section != null ? section : "UNKNOWN");
+            checkRequest.setDraft(draft != null ? draft : "UNKNOWN");
+
+            ValidationDto validationResult = checkService.check(checkRequest);
+
+            ValidationResponseDto response = ValidationResponseDto.builder()
+                    .requestId(request.getRequestId())
+                    .status("SUCCESS")
+                    .validationResult(validationResult)
+                    .errorMessage(null)
+                    .build();
+
+            String responseJson = objectMapper.writeValueAsString(response);
+            kafkaTemplate.send(VALIDATION_RESPONSE_TOPIC, request.getRequestId(), responseJson);
+
+        } catch (Exception e) {
+            log.error("AI 서버 요청 처리 실패", e);
+        }
+    }
+
+
+    @KafkaListener(topics = REVISION_REQUEST_TOPIC, groupId = "ai-server-group")
+    public void consumeRevisionRequest(String message) {
+        try {
+            RevisionRequestDto request = objectMapper.readValue(message, RevisionRequestDto.class);
+
+            ValidationDto.Issue issue = request.getIssue();
+
+            String revisionResult = checkService.revise(issue);
+
+            RevisionResponseDto response = RevisionResponseDto.builder()
+                    .requestId(request.getRequestId())
+                    .status("SUCCESS")
+                    .revisedContent(revisionResult)
+                    .errorMessage(null)
+                    .build();
+
+            String responseJson = objectMapper.writeValueAsString(response);
+            kafkaTemplate.send(REVISION_RESPONSE_TOPIC, request.getRequestId(), responseJson);
+
+        } catch (Exception e) {
+            log.error("AI 서버 요청 처리 실패", e);
+        }
+    }
+
+}
+


### PR DESCRIPTION
### ✨ 개선 사항
> 검증 및 재생성 로직에서 백엔드 -> AI 백엔드로 요청할 때, 서로 이어주는 kafka consumer 추가

<br>

### ✅ PR 체크리스트
- [ ] 커밋 컨벤션을 지켰나요?
- [ ] 관련 이슈를 연결했나요?

<br>

### 🔗 참고 사항
> 리뷰어가 참고할 만한 내용을 공유해주세요.

---
Resolved #이슈번호
